### PR TITLE
Fix "Filter Life Level" constraints

### DIFF
--- a/components/homekit/esp_hap_apple_profiles/src/hap_apple_chars.c
+++ b/components/homekit/esp_hap_apple_profiles/src/hap_apple_chars.c
@@ -932,7 +932,7 @@ hap_char_t *hap_char_filter_life_level_create(float filter_life_level)
         return NULL;
     }
 
-    hap_char_int_set_constraints(hc, 0, 100, 1);
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
 
     return hc;
 }


### PR DESCRIPTION
Took me a while to understand the whole SDK :)

According to Apple's "HomeKit Accessory Protocol Specification", the "Filter Life Level" characteristic expect the value type of `float`.
While `hap_char_filter_life_level_create(float filter_life_level)` in the `esp-homekit-sdk` expects a `float` as input, the constraints are set to integers.

This renders the service and accessory as incompatible to HomeKit.