### PR TITLE
Added doorbell service

### DIFF
--- a/components/homekit/esp_hap_apple_profiles/include/hap_apple_servs.h
+++ b/components/homekit/esp_hap_apple_profiles/include/hap_apple_servs.h
@@ -74,6 +74,7 @@ extern "C" {
 #define HAP_SERV_UUID_IRRIGATION_SYSTEM             "CF"
 #define HAP_SERV_UUID_VALVE                         "D0"
 #define HAP_SERV_UUID_FAUCET                        "D7"
+#define HAP_SERV_UUID_DOORBELL                      "121"
 
 /** Create Accessory Information Service
  *
@@ -552,6 +553,18 @@ hap_serv_t *hap_serv_valve_create(uint8_t active, uint8_t in_use, uint8_t valve_
  * @return NULL on failure
  */
 hap_serv_t *hap_serv_faucet_create(uint8_t active);
+
+/** Create Doorbell Service
+ *
+ * This API will create the Doorbell Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  programmable_switch_event  Initial value of Programmable Switch Event characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_doorbell_create(uint8_t programmable_switch_event);
 
 #ifdef __cplusplus
 }

--- a/components/homekit/esp_hap_apple_profiles/src/hap_apple_servs.c
+++ b/components/homekit/esp_hap_apple_profiles/src/hap_apple_servs.c
@@ -704,3 +704,17 @@ err:
     return NULL;
 }
 
+hap_serv_t *hap_serv_doorbell_create(uint8_t programmable_switch_event)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_DOORBELL);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_programmable_switch_event_create(programmable_switch_event)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}


### PR DESCRIPTION
The video doorbell service depends on a doorbell service which in turn depends on more services and characteristics. I've implemented that whole tree of dependencies.

The video portion of the doorbell is important because that's how the Home app connects "chimes" on the HomePods to the doorbell. The doorbell service currently works on it's own but there's no way for the Home app to configure doorbell chimes then.

The video services with the respective tlv8 configs are only stubbed out and a WIP.

_NOTE: This is a work in progress. I'm looking for feedback or help with the TLV8 configs etc. I also realize I've mistakenly auto formatted the files. I'll revert this at a later point._