### PR TITLE
Added a KConfig option to set NVS partition names for homekit use

### DIFF
--- a/components/homekit/esp_hap_platform/Kconfig
+++ b/components/homekit/esp_hap_platform/Kconfig
@@ -85,3 +85,19 @@ menu "HAP HTTP Server"
             Set the Maximum number of URI handlers that the HTTP Server should allow.
 
 endmenu
+
+menu "HAP Platform Keystore"
+
+    config HAP_PLATFORM_DEF_NVS_RUNTIME_PARTITION
+        string "Runtime NVS partition name"
+        default "nvs"
+        help
+            Set the runtime NVS partition name for HomeKit use.
+
+    config HAP_PLATFORM_DEF_NVS_FACTORY_PARTITION
+        string "Factory NVS partition name"
+        default "factory_nvs"
+        help
+            Set the factory NVS partition name for HomeKit use.
+
+endmenu

--- a/components/homekit/esp_hap_platform/src/hap_platform_keystore.c
+++ b/components/homekit/esp_hap_platform/src/hap_platform_keystore.c
@@ -25,19 +25,17 @@
 #include <nvs_flash.h>
 #include <string.h>
 
-#define HAP_PLATFORM_DEF_NVS_PARTITION          "nvs"
-#define HAP_PLATFORM_DEF_FACTORY_NVS_PARTITION  "factory_nvs"
 
 static const char *TAG = "hap_platform_keystore";
 
 char * hap_platform_keystore_get_nvs_partition_name()
 {
-    return HAP_PLATFORM_DEF_NVS_PARTITION;
+    return CONFIG_HAP_PLATFORM_DEF_NVS_RUNTIME_PARTITION;
 }
 
 char * hap_platform_keystore_get_factory_nvs_partition_name()
 {
-    return HAP_PLATFORM_DEF_FACTORY_NVS_PARTITION;
+    return CONFIG_HAP_PLATFORM_DEF_NVS_FACTORY_PARTITION;
 }
 
 #ifdef CONFIG_NVS_ENCRYPTION


### PR DESCRIPTION
Hey thanks for working on this!

Just playing with homekit things and discovered a bit of a hiccup where one already has an NVS partition (or three) and the homekit API expects to be able to read, write, and **erase** `nvs` and `nvs_factory` partitions...

This PR adds KConfig options to set the partition names, with defaults to match the original approach, so it can be used alongside any existing nvs partitions. IMO it'd be useful to dependency inject the k/v store so it could be integrated with other approaches to configuration, but for now this solves the interoperability problem.