### PR TITLE
Adds step argument to fan rotation speed api - fixes #92

### DIFF
--- a/components/homekit/esp_hap_apple_profiles/include/hap_apple_chars.h
+++ b/components/homekit/esp_hap_apple_profiles/include/hap_apple_chars.h
@@ -396,8 +396,11 @@ hap_char_t *hap_char_rotation_direction_create(int rotation_direction);
 
 /** Create Rotation Speed Characteristic
  *
- * This API creates the Rotation Speed characteristic object with other metadata
- * (format, constraints, permissions, etc.) set as per the HAP Specs
+ * This API creates the Rotation Speed characteristic object with minimal metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs. The HAP spec 
+ * defines this characteristics with both rotation_speed and step metadata. This 
+ * legacy function accepts only rotation_speed to maintain backwards compatibility, 
+ * and calls hap_char_rotation_speed_with_step_create with the default step = 1. 
  *
  * @param[in] rotation_speed Initial value of Rotation Speed
  *
@@ -406,6 +409,19 @@ hap_char_t *hap_char_rotation_direction_create(int rotation_direction);
  */
 hap_char_t *hap_char_rotation_speed_create(float rotation_speed);
 
+/** Create Rotation Speed Characteristic with step
+ *
+ * This API creates the Rotation Speed characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] rotation_speed Initial value of Rotation Speed
+ * @param[in] step Initial value of step
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_rotation_speed_with_step_create(float rotation_speed, float step);
+ 
 /** Create Saturation Characteristic
  *
  * This API creates the saturation characteristic object with other metadata

--- a/components/homekit/esp_hap_apple_profiles/src/hap_apple_chars.c
+++ b/components/homekit/esp_hap_apple_profiles/src/hap_apple_chars.c
@@ -298,13 +298,21 @@ hap_char_t *hap_char_rotation_direction_create(int rotation_direction)
 /* Char: Rotation Speed */
 hap_char_t *hap_char_rotation_speed_create(float rotation_speed)
 {
+    hap_char_t *hc = hap_char_rotation_speed_with_step_create(rotation_speed, 1);
+
+    return hc;
+}
+
+/* Char: Rotation Speed with step */
+hap_char_t *hap_char_rotation_speed_with_step_create(float rotation_speed, float step)
+{
     hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_ROTATION_SPEED,
                                            HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, rotation_speed);
     if (!hc) {
         return NULL;
     }
 
-    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+    hap_char_float_set_constraints(hc, 0.0, 100.0, step);
     hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
 
     return hc;


### PR DESCRIPTION
HAP specification defines a step parameter on the rotation speed characteristic. 

esp-homekit-sdk does not expose the step parameter on hap_char_rotation_speed_create. 

This commit exposes the step parameter, while also maintain backward compatibility with existing implementations. 

This commit fixes issue #92  