### PR TITLE
changed CMAKE_CURRENT_LIST_DIR to HOMEKIT_PATH in examples CMakeLists…

### DIFF
--- a/examples/aws-iot/CMakeLists.txt
+++ b/examples/aws-iot/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT DEFINED ENV{AWS_IOT_PATH})
     message(FATAL_ERROR "Please set AWS_IOT_PATH to esp-aws-iot repo")
 endif(NOT DEFINED ENV{AWS_IOT_PATH})
 
-set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit $ENV{AWS_IOT_PATH}/../ ${CMAKE_CURRENT_LIST_DIR}/../common)
+set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit $ENV{AWS_IOT_PATH}/../ ${HOMEKIT_PATH}/examples/common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(aws-iot)

--- a/examples/bridge/CMakeLists.txt
+++ b/examples/bridge/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
   set(HOMEKIT_PATH ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif(DEFINED ENV{HOMEKIT_PATH})
 
-set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${CMAKE_CURRENT_LIST_DIR}/../common)
+set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${HOMEKIT_PATH}/examples/common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(bridge)

--- a/examples/data_tlv8/CMakeLists.txt
+++ b/examples/data_tlv8/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   set(HOMEKIT_PATH ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif(DEFINED ENV{HOMEKIT_PATH})
 
-set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${CMAKE_CURRENT_LIST_DIR}/../common)
+set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${HOMEKIT_PATH}/examples/common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(data_tlv8)

--- a/examples/emulator/CMakeLists.txt
+++ b/examples/emulator/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   set(HOMEKIT_PATH ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif(DEFINED ENV{HOMEKIT_PATH})
 
-set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${CMAKE_CURRENT_LIST_DIR}/../common)
+set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${HOMEKIT_PATH}/examples/common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(emulator)

--- a/examples/fan/CMakeLists.txt
+++ b/examples/fan/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   set(HOMEKIT_PATH ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif(DEFINED ENV{HOMEKIT_PATH})
 
-set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${CMAKE_CURRENT_LIST_DIR}/../common)
+set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${HOMEKIT_PATH}/examples/common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(fan)

--- a/examples/lightbulb/CMakeLists.txt
+++ b/examples/lightbulb/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   set(HOMEKIT_PATH ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif(DEFINED ENV{HOMEKIT_PATH})
 
-set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${CMAKE_CURRENT_LIST_DIR}/../common)
+set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${HOMEKIT_PATH}/examples/common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(lightbulb)

--- a/examples/smart_outlet/CMakeLists.txt
+++ b/examples/smart_outlet/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   set(HOMEKIT_PATH ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif(DEFINED ENV{HOMEKIT_PATH})
 
-set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${CMAKE_CURRENT_LIST_DIR}/../common)
+set(EXTRA_COMPONENT_DIRS ${HOMEKIT_PATH}/components ${HOMEKIT_PATH}/components/homekit ${HOMEKIT_PATH}/examples/common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(smart_outlet)


### PR DESCRIPTION
changed CMAKE_CURRENT_LIST_DIR to HOMEKIT_PATH in examples CMakeLists.txt file so examples can be copied to directories outside the examples directory